### PR TITLE
Do not use absolute URLs

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -28,7 +28,7 @@ func (as *AuthenticationService) UsingGithubToken(githubToken string) (AccessTok
 	if githubToken == "" {
 		return "", nil, fmt.Errorf("unable to authenticate client; empty github token provided")
 	}
-	var u string = "/auth/github"
+	var u string = "auth/github"
 	var b map[string]string = map[string]string{"github_token": githubToken}
 
 	req, err := as.client.NewRequest("POST", u, b, nil)

--- a/branches.go
+++ b/branches.go
@@ -51,7 +51,7 @@ type getBranchResponse struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BranchesService) ListFromRepository(slug string) ([]Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%v/branches", slug), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%v/branches", slug), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (bs *BranchesService) ListFromRepository(slug string) ([]Branch, *http.Resp
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BranchesService) Get(repoSlug string, branchId uint) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%v/branches/%d", repoSlug, branchId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%v/branches/%d", repoSlug, branchId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +99,7 @@ func (bs *BranchesService) Get(repoSlug string, branchId uint) (*Branch, *http.R
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BranchesService) GetFromSlug(repoSlug string, branchSlug string) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%v/branches/%v", repoSlug, branchSlug), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%v/branches/%v", repoSlug, branchSlug), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builds.go
+++ b/builds.go
@@ -72,7 +72,7 @@ type BuildListOptions struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BuildsService) List(opt *BuildListOptions) ([]Build, []Job, []Commit, *http.Response, error) {
-	u, err := urlWithOptions("/builds", opt)
+	u, err := urlWithOptions("builds", opt)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -95,7 +95,7 @@ func (bs *BuildsService) List(opt *BuildListOptions) ([]Build, []Job, []Commit, 
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BuildsService) ListFromRepository(slug string, opt *BuildListOptions) ([]Build, []Job, []Commit, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%v/builds", slug), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%v/builds", slug), opt)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -118,7 +118,7 @@ func (bs *BuildsService) ListFromRepository(slug string, opt *BuildListOptions) 
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BuildsService) Get(id uint) (*Build, []Job, *Commit, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/builds/%d", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("builds/%d", id), nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -141,7 +141,7 @@ func (bs *BuildsService) Get(id uint) (*Build, []Job, *Commit, *http.Response, e
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BuildsService) Cancel(id uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/builds/%d/cancel", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("builds/%d/cancel", id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (bs *BuildsService) Cancel(id uint) (*http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (bs *BuildsService) Restart(id uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/builds/%d/restart", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("builds/%d/restart", id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/commits.go
+++ b/commits.go
@@ -40,7 +40,7 @@ type Commit struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (cs *CommitsService) GetFromBuild(buildId uint) (*Commit, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/builds/%d", buildId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("builds/%d", buildId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,7 +63,7 @@ func (cs *CommitsService) GetFromBuild(buildId uint) (*Commit, *http.Response, e
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (cs *CommitsService) ListFromRepository(repositorySlug string) ([]Commit, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%s/builds", repositorySlug), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%s/builds", repositorySlug), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jobs.go
+++ b/jobs.go
@@ -91,7 +91,7 @@ func (jfo *JobFindOptions) IsValid() bool {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#jobs
 func (js *JobsService) Get(id uint) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/jobs/%d", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("jobs/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +114,7 @@ func (js *JobsService) Get(id uint) (*Job, *http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#jobs
 func (js *JobsService) ListFromBuild(buildId uint) ([]Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/builds/%d", buildId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("builds/%d", buildId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,7 +145,7 @@ func (js *JobsService) Find(opt *JobFindOptions) ([]Job, *http.Response, error) 
 		)
 	}
 
-	u, err := urlWithOptions("/jobs", opt)
+	u, err := urlWithOptions("jobs", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,7 +168,7 @@ func (js *JobsService) Find(opt *JobFindOptions) ([]Job, *http.Response, error) 
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#jobs
 func (js *JobsService) Cancel(id uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/jobs/%d/cancel", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("jobs/%d/cancel", id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (js *JobsService) Cancel(id uint) (*http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#jobs
 func (js *JobsService) Restart(id uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/jobs/%d/restart", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("jobs/%d/restart", id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/logs.go
+++ b/logs.go
@@ -39,7 +39,7 @@ type getLogResponse struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#logs
 func (ls *LogsService) Get(logId uint) (*Log, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/logs/%d", logId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("logs/%d", logId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (ls *LogsService) Get(logId uint) (*Log, *http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#logs
 func (ls *LogsService) GetByJob(jobId uint) (*Log, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/jobs/%d/log", jobId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("jobs/%d/log", jobId), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/repositories.go
+++ b/repositories.go
@@ -74,7 +74,7 @@ type getRepositoryResponse struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#repositories
 func (rs *RepositoriesService) Find(opt *RepositoryListOptions) ([]Repository, *http.Response, error) {
-	u, err := urlWithOptions("/repos", opt)
+	u, err := urlWithOptions("repos", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,7 +97,7 @@ func (rs *RepositoriesService) Find(opt *RepositoryListOptions) ([]Repository, *
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#repositories
 func (rs *RepositoriesService) GetFromSlug(slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%s", slug), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%s", slug), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,7 +120,7 @@ func (rs *RepositoriesService) GetFromSlug(slug string) (*Repository, *http.Resp
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#repositories
 func (rs *RepositoriesService) Get(id uint) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repos/%d", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repos/%d", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/requests.go
+++ b/requests.go
@@ -67,7 +67,7 @@ type RequestsListOptions struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#builds
 func (rs *RequestsService) Get(requestId uint) (*Request, *Commit, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/requests/%d", requestId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("requests/%d", requestId), nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -96,7 +96,7 @@ func (rs *RequestsService) ListFromRepository(slug string, opt *RequestsListOpti
 		opt = &RequestsListOptions{Slug: slug}
 	}
 
-	u, err := urlWithOptions("/requests", opt)
+	u, err := urlWithOptions("requests", opt)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -42,7 +42,7 @@ type getUserResponse struct {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#users
 func (us *UsersService) GetAuthenticated() (*User, *http.Response, error) {
-	u, err := urlWithOptions("/users/", nil)
+	u, err := urlWithOptions("users/", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -65,7 +65,7 @@ func (us *UsersService) GetAuthenticated() (*User, *http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#users
 func (us *UsersService) Get(userId uint) (*User, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/users/%d", userId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("users/%d", userId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,7 +90,7 @@ func (us *UsersService) Get(userId uint) (*User, *http.Response, error) {
 //
 // Travis CI API docs: http://docs.travis-ci.com/api/#users
 func (us *UsersService) Sync() (*http.Response, error) {
-	u, err := urlWithOptions("/users/sync", nil)
+	u, err := urlWithOptions("users/sync", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm using Travis on Github Enterprise and the API base URL looks like `https://travis.example.com/api`.

Using absolute URLs doesn't work for base URLs with a path, e.g. `/auth/github` is translated to `https://travis.example.com/auth/github` instead of `https://travis.example.com/api/auth/github`.